### PR TITLE
Bug 951530 - [b2g-bluetooth][HFP] Configure bluedroid for B2G, f=shuang, r=echou

### DIFF
--- a/btif/src/btif_hf.c
+++ b/btif/src/btif_hf.c
@@ -61,14 +61,11 @@
 #endif
 
 #ifndef BTIF_HF_FEATURES
+/* B2G supported BRSF values */
 #define BTIF_HF_FEATURES   ( BTA_AG_FEAT_3WAY | \
-                             BTA_AG_FEAT_ECNR   | \
                              BTA_AG_FEAT_REJECT | \
                              BTA_AG_FEAT_ECS    | \
-                             BTA_AG_FEAT_EXTERR | \
-                             BTA_AG_FEAT_BTRH   | \
-                             BTA_AG_FEAT_VREC   | \
-                             BTA_AG_FEAT_UNAT)
+                             BTA_AG_FEAT_EXTERR)
 #endif
 
 #define BTIF_HF_ID_1        0

--- a/include/bt_target.h
+++ b/include/bt_target.h
@@ -3752,7 +3752,8 @@ The maximum number of payload octets that the local device can receive in a sing
 #endif
 
 #ifndef BTA_AG_CHLD_VAL
-#define BTA_AG_CHLD_VAL  "(0,1,2,3)"
+/* B2G supported CHLD values */
+#define BTA_AG_CHLD_VAL  "(0,1,2)"
 #endif
 
 /* Set the CIND to match HFP 1.5 */


### PR DESCRIPTION
Changes:
- remove echo cancellation and voice recognition flags from BRSF
- remove CHLD=3 from supported CHLD command list
