### PR TITLE
Wrap non-AOSP pin_request_callback parameter with Q_BLUETOOTH

### DIFF
--- a/btif/src/btif_dm.c
+++ b/btif/src/btif_dm.c
@@ -1082,8 +1082,13 @@ static void btif_dm_pin_req_evt(tBTA_DM_PIN_REQ *p_pin_req)
             }
         }
     }
+#ifdef Q_BLUETOOTH
     HAL_CBACK(bt_hal_cbacks, pin_request_cb,
                      &bd_addr, &bd_name, cod, secure);
+#else
+    HAL_CBACK(bt_hal_cbacks, pin_request_cb,
+                     &bd_addr, &bd_name, cod);
+#endif
 }
 
 /*******************************************************************************
@@ -3489,8 +3494,13 @@ static void btif_dm_ble_passkey_req_evt(tBTA_DM_PIN_REQ *p_pin_req)
 
     cod = COD_UNCLASSIFIED;
 
+#ifdef Q_BLUETOOTH
     HAL_CBACK(bt_hal_cbacks, pin_request_cb,
               &bd_addr, &bd_name, cod, FALSE);
+#else
+    HAL_CBACK(bt_hal_cbacks, pin_request_cb,
+              &bd_addr, &bd_name, cod);
+#endif
 }
 
 

--- a/test/blegatt_test/gatt_test.c
+++ b/test/blegatt_test/gatt_test.c
@@ -882,7 +882,11 @@ static void discovery_state_changed(bt_discovery_state_t state)
 }
 
 
+#ifdef Q_BLUETOOTH
 static void pin_request_cb(bt_bdaddr_t *remote_bd_addr, bt_bdname_t *bd_name, uint32_t cod, uint8_t secure )
+#else
+static void pin_request_cb(bt_bdaddr_t *remote_bd_addr, bt_bdname_t *bd_name, uint32_t cod )
+#endif
 {
     int ret = 0;
     remote_bd_address = remote_bd_addr;


### PR DESCRIPTION
Change-Id: I725d64155e2e990987049adf0822086981cc6afc
