### PR TITLE
Bug 1188461: Remove include statements with hard-coded paths

### DIFF
--- a/bta/ag/bta_ag_cfg.c
+++ b/bta/ag/bta_ag_cfg.c
@@ -23,7 +23,6 @@
  *
  ******************************************************************************/
 
-#include "../../../../../gecko/dom/bluetooth/bluedroid/b2g_bdroid_buildcfg.h"
 #include "gki.h"
 #include "bta_api.h"
 #include "bta_ag_api.h"

--- a/btif/src/btif_hf.c
+++ b/btif/src/btif_hf.c
@@ -27,7 +27,6 @@
  *
  ***********************************************************************************/
 
-#include "../../../../../gecko/dom/bluetooth/bluedroid/b2g_bdroid_buildcfg.h"
 #include <hardware/bluetooth.h>
 #include <hardware/bt_hf.h>
 #include <stdlib.h>


### PR DESCRIPTION
The respectivei header files will be included from the configuration
headers. The include's search path is configured in the environment
variable $(BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR).
